### PR TITLE
Modal scroll

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,7 +1,7 @@
-import React, {useCallback, useEffect, useRef} from 'react';
-import {createPortal} from 'react-dom';
+import React, { useCallback, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import OutsideClickHandler from 'react-outside-click-handler';
-import {disableBodyScroll, enableBodyScroll} from 'body-scroll-lock';
+import { clearAllBodyScrollLocks, disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import cn from 'classnames';
 
 import Icon from '../Icon';
@@ -10,12 +10,12 @@ import styles from './Modal.module.scss';
 
 // TODO: убрать any
 const Modal: React.FC<any> = ({
-                                outerClassName,
-                                containerClassName,
-                                visible,
-                                onClose,
-                                children,
-                              }) => {
+  outerClassName,
+  containerClassName,
+  visible,
+  onClose,
+  children,
+}) => {
   const escFunction = useCallback(
     (e) => {
       if (e.keyCode === 27) {
@@ -40,6 +40,7 @@ const Modal: React.FC<any> = ({
     } else {
       enableBodyScroll(scrollRef.current!);
     }
+    return () => clearAllBodyScrollLocks();
   }, [visible]);
 
   return createPortal(
@@ -50,7 +51,7 @@ const Modal: React.FC<any> = ({
             <div className={cn(styles.container, containerClassName)}>
               {children}
               <button type="button" className={styles.close} onClick={onClose}>
-                <Icon name="close" size="14"/>
+                <Icon name="close" size="14" />
               </button>
             </div>
           </OutsideClickHandler>


### PR DESCRIPTION
Пофиксил enableScroll после закрытия модалки.
сейчас выскакивает ошибка:
**enableBodyScroll unsuccessful - targetElement must be provided when calling enableBodyScroll on IOS devices.**

От ошибки можно избавиться, если удалить 
 else {
      enableBodyScroll(scrollRef.current!);
    }